### PR TITLE
build: semantic release on push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - development
+  push:
+    branches:
+      - main
 
 jobs:
   ci:


### PR DESCRIPTION
Semantic release did not execute on the last push to main. This commit should fix the issue.