### PR TITLE
build: fix readthedocs dependency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.9"
 
       - name: Check-out repository
         uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.9"
 
       - name: Check-out repository
         uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
 
 # Configuration
 python:
-  version: 3.10
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - ncurses=6.3
   - openssl=3.0.7
   - pip=22.3.1
-  - python=3.10.8
+  - python=3.9.15
   - readline=8.1.2
   - tk=8.6.12
   - tzdata=2022g
@@ -123,7 +123,6 @@ dependencies:
       - sphinxcontrib-jsmath==1.0.1
       - sphinxcontrib-qthelp==1.0.3
       - sphinxcontrib-serializinghtml==1.1.5
-      - spinneret==0.0.0
       - sqlalchemy==1.4.46
       - stack-data==0.6.2
       - tabulate==0.9.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -92,6 +92,7 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -857,6 +858,7 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
@@ -1020,6 +1022,7 @@ mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
@@ -1325,6 +1328,7 @@ babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.14,<0.20"
 imagesize = ">=1.3"
+importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
 Pygments = ">=2.12"
@@ -1658,8 +1662,8 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "650def7ca5e861f4ce413d0b90e3f177ecb0efd100dd807cc5ab358af3b92888"
+python-versions = "^3.9"
+content-hash = "1fb84139de4306ca9336c66fb22143cd984576c3bd278228079f5bcd9f3eedba"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 pandas = "^1.5.2"
 rdflib = "^6.2.0"
 lxml = "^4.9.2"
@@ -24,6 +24,7 @@ sphinx-rtd-theme = "^1.1.1"
 pylint = "^2.15.10"
 black = "^22.12.0"
 python-semantic-release = "^7.32.2"
+myst-nb = "^0.17.1"
 
 [tool.semantic_release]
 version_variable = "pyproject.toml:version" # version location

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,6 @@ sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-spinneret==0.0.0
 SQLAlchemy==1.4.46
 stack-data==0.6.2
 tabulate==0.9.0


### PR DESCRIPTION
Read the Docs was having a hard time with Python >=3.10 declared for this package. The error was actually thrown from Sphinx in the context of Read the Docs, but the same error coud not be reproduced locally. The error: module "types" has no attribute "UnionType". Reverting back to Python 3.9, a version used in another project and that is not encountering this error.