### PR TITLE
refactor: rename `combine_jsonld_files` to `load_metadata`

### DIFF
--- a/src/spinneret/graph.py
+++ b/src/spinneret/graph.py
@@ -3,10 +3,10 @@
 from rdflib import Graph
 
 
-def combine_jsonld_files(files: list) -> Graph:
+def load_metadata(files: list) -> Graph:
     """
-    :param files:   List of file paths to JSON-LD files
-    :returns:       Graph of the combined JSON-LD files
+    :param files:   List of file paths to metadata in JSON-LD format
+    :returns:       Graph of the combined metadata files
     """
     g = Graph()
     for filename in files:
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     WORKING_DIR = "/Users/csmith/Data/soso/all_edi_test_results"
     list_of_files = ["edi.1.1.json", "edi.3.10.json", "edi.5.5.json"]
     working_files = [WORKING_DIR + "/" + f for f in list_of_files]
-    res = combine_jsonld_files(working_files)
+    res = load_metadata(working_files)
 
     # # Full example
     # working_dir = "/Users/csmith/Data/soso/all_edi_test_results"
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     # # import random
     # # working_files = random.choices(working_files, k=1000)
     # # Create full graph
-    # g = combine_jsonld_files(working_files)
+    # g = load_metadata(working_files)
 
     # # Serialize to file
     # output_file = "/Users/csmith/Data/soso/all_edi_test_graph/combined.ttl"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,13 +2,13 @@
 
 from os import listdir
 import importlib
-import spinneret.graph
+from spinneret.graph import load_metadata
 
 
 def test_combine_jsonld_files():
-    """Test combine_jsonld_files"""
+    """Test load_metadata"""
     data_dir = str(importlib.resources.files("spinneret.data")) + "/jsonld"
     files = [data_dir + "/" + f for f in listdir(data_dir)]
-    res = spinneret.graph.combine_jsonld_files(files)
+    res = load_metadata(files)
     assert res is not None
     assert len(res) > 0


### PR DESCRIPTION
Rename the function to `load_metadata` to more accurately reflect its purpose of loading multiple metadata files into a graph.