### PR TITLE
feat: integrate metadata and vocabulary loading into `load_graph`

### DIFF
--- a/src/spinneret/graph.py
+++ b/src/spinneret/graph.py
@@ -28,6 +28,32 @@ def load_vocabularies(files: list) -> Graph:
     return g
 
 
+def load_graph(metadata_files: list = None, vocabulary_files: list = None) -> Graph:
+    """
+    :param metadata_files: List of file paths to metadata in JSON-LD format
+    :param vocabulary_files: List of file paths to vocabularies
+    :returns: Graph of the combined metadata and vocabularies
+    :notes: If no vocabulary files are provided, only the metadata are loaded
+        into the graph, and vice versa if no metadata files are provided.
+
+        Vocabulary formats are identified by the file extension according
+        to `rdflib.util.guess_format`
+    """
+    g = Graph()
+
+    # Load metadata
+    if metadata_files is not None:
+        for filename in metadata_files:
+            g.parse(filename)
+
+    # Load vocabularies
+    if vocabulary_files is not None:
+        for filename in vocabulary_files:
+            g.parse(filename, format=guess_format(filename))
+
+    return g
+
+
 if __name__ == "__main__":
     # Example usage
     WORKING_DIR = "/Users/csmith/Data/soso/all_edi_test_results"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,7 @@
 
 from os import listdir
 import importlib
-from spinneret.graph import load_metadata, load_vocabularies
+from spinneret.graph import load_metadata, load_vocabularies, load_graph
 
 
 def test_combine_jsonld_files():
@@ -21,3 +21,26 @@ def test_load_vocabularies():
     res = load_vocabularies(files)
     assert res is not None
     assert len(res) > 0
+
+
+def test_load_graph():
+    """Test load_graph"""
+
+    # Load_metadata
+    data_dir = str(importlib.resources.files("spinneret.data")) + "/jsonld"
+    metadata_files = [data_dir + "/" + f for f in listdir(data_dir)]
+    res = load_graph(metadata_files=metadata_files)
+    assert res is not None
+    assert len(res) == 650  # based on current metadata files
+
+    # Load_vocabularies
+    data_dir = "tests/data/vocab"
+    vocabulary_files = [data_dir + "/" + f for f in listdir(data_dir)]
+    res = load_graph(vocabulary_files=vocabulary_files)
+    assert res is not None
+    assert len(res) == 18  # based on current vocabulary files
+
+    # Load both metadata and vocabularies
+    res = load_graph(metadata_files=metadata_files, vocabulary_files=vocabulary_files)
+    assert res is not None
+    assert len(res) == 668  # based on current metadata and vocabulary files


### PR DESCRIPTION
Create the `load_graph` function to handle both metadata and vocabulary loading in a unified manner. This allows for flexible usage scenarios where only metadata or vocabulary files are provided.

This approach addresses the `ConjunctiveGraph` issue outlined in rdflib version 7.0.0 documentation.