### PR TITLE
refactor: deprecate existing load functions in favor of `load_graph`

### DIFF
--- a/src/spinneret/graph.py
+++ b/src/spinneret/graph.py
@@ -4,30 +4,6 @@ from rdflib import Graph
 from rdflib.util import guess_format
 
 
-def load_metadata(files: list) -> Graph:
-    """
-    :param files:   List of file paths to metadata in JSON-LD format
-    :returns:       Graph of the combined metadata files
-    """
-    g = Graph()
-    for filename in files:
-        g.parse(filename)
-    return g
-
-
-def load_vocabularies(files: list) -> Graph:
-    """
-    :param files:   List of file paths to vocabularies
-    :returns:       Graph of the combined vocabularies
-    :notes: Vocabulary formats are identified by the file extension according
-        to `rdflib.util.guess_format`
-    """
-    g = Graph()
-    for filename in files:
-        g.parse(filename, format=guess_format(filename))
-    return g
-
-
 def load_graph(metadata_files: list = None, vocabulary_files: list = None) -> Graph:
     """
     :param metadata_files: List of file paths to metadata in JSON-LD format
@@ -59,7 +35,7 @@ if __name__ == "__main__":
     WORKING_DIR = "/Users/csmith/Data/soso/all_edi_test_results"
     list_of_files = ["edi.1.1.json", "edi.3.10.json", "edi.5.5.json"]
     working_files = [WORKING_DIR + "/" + f for f in list_of_files]
-    res = load_metadata(working_files)
+    res = load_graph(metadata_files=working_files)
 
     # # Full example
     # working_dir = "/Users/csmith/Data/soso/all_edi_test_results"
@@ -72,7 +48,7 @@ if __name__ == "__main__":
     # # import random
     # # working_files = random.choices(working_files, k=1000)
     # # Create full graph
-    # g = load_metadata(working_files)
+    # g = load_graph(metadata_files=working_files)
 
     # # Serialize to file
     # output_file = "/Users/csmith/Data/soso/all_edi_test_graph/combined.ttl"
@@ -93,9 +69,8 @@ if __name__ == "__main__":
     # res = g.query(lake_query)
     # for row in res:
     #     print(row)
-    #
+
     # # Iterate through the namespace bindings
     # ns_manager = g.namespace_manager
     # for prefix, uri in ns_manager.namespaces():
     #     print(f"Prefix: {prefix}, URI: {uri}")
-    #

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,25 +2,7 @@
 
 from os import listdir
 import importlib
-from spinneret.graph import load_metadata, load_vocabularies, load_graph
-
-
-def test_combine_jsonld_files():
-    """Test load_metadata"""
-    data_dir = str(importlib.resources.files("spinneret.data")) + "/jsonld"
-    files = [data_dir + "/" + f for f in listdir(data_dir)]
-    res = load_metadata(files)
-    assert res is not None
-    assert len(res) > 0
-
-
-def test_load_vocabularies():
-    """Test load_vocabularies"""
-    data_dir = "tests/data/vocab"
-    files = [data_dir + "/" + f for f in listdir(data_dir)]
-    res = load_vocabularies(files)
-    assert res is not None
-    assert len(res) > 0
+from spinneret.graph import load_graph
 
 
 def test_load_graph():


### PR DESCRIPTION
Deprecated the `load_metadata` and `load_vocabularies` functions in favor of the `load_graph` function. This unified approach preserves blank node references, addressing limitations of the `ConjunctiveGraph` object as outlined in rdflib version 7.0.0 documentation.