### PR TITLE
refactor: rename `load_graph` to `create_graph` for clarity

### DIFF
--- a/src/spinneret/graph.py
+++ b/src/spinneret/graph.py
@@ -4,7 +4,7 @@ from rdflib import Graph
 from rdflib.util import guess_format
 
 
-def load_graph(metadata_files: list = None, vocabulary_files: list = None) -> Graph:
+def create_graph(metadata_files: list = None, vocabulary_files: list = None) -> Graph:
     """
     :param metadata_files: List of file paths to metadata in JSON-LD format
     :param vocabulary_files: List of file paths to vocabularies
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     WORKING_DIR = "/Users/csmith/Data/soso/all_edi_test_results"
     list_of_files = ["edi.1.1.json", "edi.3.10.json", "edi.5.5.json"]
     working_files = [WORKING_DIR + "/" + f for f in list_of_files]
-    res = load_graph(metadata_files=working_files)
+    res = create_graph(metadata_files=working_files)
 
     # # Full example
     # working_dir = "/Users/csmith/Data/soso/all_edi_test_results"
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     # # import random
     # # working_files = random.choices(working_files, k=1000)
     # # Create full graph
-    # g = load_graph(metadata_files=working_files)
+    # g = create_graph(metadata_files=working_files)
 
     # # Serialize to file
     # output_file = "/Users/csmith/Data/soso/all_edi_test_graph/combined.ttl"

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -10,7 +10,7 @@ from soso.utilities import delete_null_values, generate_citation_from_doi
 from spinneret import workbook
 from spinneret.annotator import annotate_workbook, annotate_eml
 from spinneret.utilities import load_configuration
-from spinneret.graph import load_graph
+from spinneret.graph import create_graph
 
 
 def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
@@ -247,7 +247,7 @@ def create_kgraph(soso_dir: str, vocabulary_dir: str) -> Graph:
     ]  # Filter out non-TTL and non-OWL files
 
     # Load knowledge graph
-    kgraph = load_graph(metadata_files=soso_files, vocabulary_files=vocabulary_files)
+    kgraph = create_graph(metadata_files=soso_files, vocabulary_files=vocabulary_files)
 
     return kgraph
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,27 +2,27 @@
 
 from os import listdir
 import importlib
-from spinneret.graph import load_graph
+from spinneret.graph import create_graph
 
 
-def test_load_graph():
-    """Test load_graph"""
+def test_create_graph():
+    """Test create_graph"""
 
     # Load_metadata
     data_dir = str(importlib.resources.files("spinneret.data")) + "/jsonld"
     metadata_files = [data_dir + "/" + f for f in listdir(data_dir)]
-    res = load_graph(metadata_files=metadata_files)
+    res = create_graph(metadata_files=metadata_files)
     assert res is not None
     assert len(res) == 650  # based on current metadata files
 
     # Load_vocabularies
     data_dir = "tests/data/vocab"
     vocabulary_files = [data_dir + "/" + f for f in listdir(data_dir)]
-    res = load_graph(vocabulary_files=vocabulary_files)
+    res = create_graph(vocabulary_files=vocabulary_files)
     assert res is not None
     assert len(res) == 18  # based on current vocabulary files
 
     # Load both metadata and vocabularies
-    res = load_graph(metadata_files=metadata_files, vocabulary_files=vocabulary_files)
+    res = create_graph(metadata_files=metadata_files, vocabulary_files=vocabulary_files)
     assert res is not None
     assert len(res) == 668  # based on current metadata and vocabulary files


### PR DESCRIPTION
Rename the function to `create_graph` to better reflect its primary purpose of constructing the knowledge graph from various data sources, rather than solely loading an existing graph.