### PR TITLE
feat: ensure EML userId is a URL for linked data compatibility

### DIFF
--- a/src/spinneret/shadow.py
+++ b/src/spinneret/shadow.py
@@ -1,1 +1,31 @@
 """A module for creating shadow metadata"""
+
+from urllib.parse import urljoin
+from lxml import etree
+from spinneret.utilities import is_uri
+
+
+def convert_userid_to_url(eml: etree.ElementTree) -> etree.ElementTree:
+    """
+    :param eml: An EML document
+    :returns:   An EML document with userId elements converted to URLs, if
+        not already, and if possible.
+    """
+    # Find all userId elements with a directory attribute
+    userid_elements = eml.xpath("//userId[@directory]")
+
+    for element in userid_elements:
+        directory = element.attrib["directory"]
+        value = element.text
+
+        # If the directory isn't a URL, then there it is not possible to
+        # convert the value to a URL so skip this element
+        if not is_uri(directory):
+            continue
+
+        # If the value is not a URL, then convert it to a URL
+        if not is_uri(value):
+            new_value = urljoin(directory, value)
+            element.text = new_value
+
+    return eml

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,60 @@
+"""Test shadow code"""
+
+from lxml import etree
+from spinneret.shadow import convert_userid_to_url
+
+
+def test_convert_userid_to_url():
+    """Test convert_userid_to_url"""
+
+    # Elements with missing directory attribute are not processed
+    data = """
+    <root>
+        <userId>user1</userId>
+    </root>
+    """
+    eml = etree.ElementTree(etree.fromstring(data))
+    res = convert_userid_to_url(eml)
+    assert res.xpath("//userId")[0].text == "user1"
+
+    # If the directory attribute is not a URL, then the element is not processed
+    data = """
+    <root>
+        <userId directory="not_a_url">user1</userId>
+    </root>
+    """
+    eml = etree.ElementTree(etree.fromstring(data))
+    res = convert_userid_to_url(eml)
+    assert res.xpath("//userId")[0].text == "user1"
+
+    # If the directory attribute is a URL, then the element is processed. This
+    # also tests that the value is converted to a URL if it is not already a URL.
+    data = """
+    <root>
+        <userId directory="https://example.com/">user1</userId>
+    </root>
+    """
+    eml = etree.ElementTree(etree.fromstring(data))
+    res = convert_userid_to_url(eml)
+    assert res.xpath("//userId")[0].text == "https://example.com/user1"
+
+    # If the value is already a URL, then the element is returned as is
+    data = """
+    <root>
+        <userId directory="https://example.com/">https://example.com/user1</userId>
+    </root>
+    """
+    eml = etree.ElementTree(etree.fromstring(data))
+    res = convert_userid_to_url(eml)
+    assert res.xpath("//userId")[0].text == "https://example.com/user1"
+
+    # Check that the value is returned as is if the directory is not a URL but
+    # the value is a URL
+    data = """
+    <root>
+        <userId directory="not_a_url">https://example.com/user1</userId>
+    </root>
+    """
+    eml = etree.ElementTree(etree.fromstring(data))
+    res = convert_userid_to_url(eml)
+    assert res.xpath("//userId")[0].text == "https://example.com/user1"


### PR DESCRIPTION
Modify the EML userId element to be a URL, whenever possible, facilitating linked data compatibility. If the current value isn't a URL, it's converted using the directory attribute as a base URL.

This function addresses a practice, previously recommended by EDI, of setting the base URL as the directory attribute and the remaining identifier as the element value. This practice has been recently deprecated.