### PR TITLE
refactor: rename `is_uri` function for accuracy

### DIFF
--- a/src/spinneret/shadow.py
+++ b/src/spinneret/shadow.py
@@ -2,7 +2,7 @@
 
 from urllib.parse import urljoin
 from lxml import etree
-from spinneret.utilities import is_uri
+from spinneret.utilities import is_url
 
 
 def convert_userid_to_url(eml: etree.ElementTree) -> etree.ElementTree:
@@ -20,11 +20,11 @@ def convert_userid_to_url(eml: etree.ElementTree) -> etree.ElementTree:
 
         # If the directory isn't a URL, then there it is not possible to
         # convert the value to a URL so skip this element
-        if not is_uri(directory):
+        if not is_url(directory):
             continue
 
         # If the value is not a URL, then convert it to a URL
-        if not is_uri(value):
+        if not is_url(value):
             new_value = urljoin(directory, value)
             element.text = new_value
 

--- a/src/spinneret/utilities.py
+++ b/src/spinneret/utilities.py
@@ -33,11 +33,11 @@ def delete_empty_tags(xml: etree._ElementTree) -> etree._ElementTree:
     return xml
 
 
-def is_uri(text: str) -> bool:
+def is_url(text: str) -> bool:
     """
     :param text: The string to be checked.
-    :returns: True if the string is likely a URI, False otherwise.
-    :note: A string is considered a URI if it has scheme and network
+    :returns: True if the string is likely a URL, False otherwise.
+    :note: A string is considered a URL if it has scheme and network
         location values.
     """
     res = urlparse(text)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -2,7 +2,7 @@
 
 from lxml import etree
 from spinneret import datasets
-from spinneret.utilities import delete_empty_tags, is_uri
+from spinneret.utilities import delete_empty_tags, is_url
 
 
 def test_delete_empty_tags():
@@ -26,6 +26,6 @@ def test_delete_empty_tags():
 
 
 def test_is_uri():
-    """Test that a string is a URI or not"""
-    assert is_uri("http://purl.dataone.org/odo/ECSO_00001203") is True
-    assert is_uri("A free text description.") is False
+    """Test that a string is a URL or not"""
+    assert is_url("http://purl.dataone.org/odo/ECSO_00001203") is True
+    assert is_url("A free text description.") is False


### PR DESCRIPTION
Rename the `is_uri` function to `is_url` for accuracy, as the function specifically checks for URLs, not URIs.