### PR TITLE
refactor: create soso files from shadow EML files

### DIFF
--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -312,8 +312,8 @@ if __name__ == "__main__":
     # )
 
     # create_soso_files(
-    #     eml_dir="/Users/csmith/Data/kgraph/eml/test",
-    #     output_dir="/Users/csmith/Data/kgraph/soso/test",
+    #     eml_dir="/Users/csmith/Data/kgraph/eml/shadow",
+    #     output_dir="/Users/csmith/Data/kgraph/soso/raw",
     # )
 
     # g = create_kgraph(


### PR DESCRIPTION
Process shadow EML files by passing them as input to `main.create_soso_files`. Rename the soso file directory to `raw` to imply different processing levels for future use.