### PR TITLE
feat: introduce workbook row initialization

### DIFF
--- a/src/spinneret/workbook.py
+++ b/src/spinneret/workbook.py
@@ -181,3 +181,35 @@ def get_description(element: etree._Element) -> str:
     else:
         description = None
     return description
+
+
+def list_workbook_columns() -> list:
+    """
+    :returns: A list of the columns in the workbook.
+    """
+    res = [
+        "package_id",
+        "url",
+        "element",
+        "element_id",
+        "element_xpath",
+        "context",
+        "description",
+        "subject",
+        "predicate",
+        "predicate_id",
+        "object",
+        "object_id",
+        "author",
+        "date",
+        "comment",
+    ]
+    return res
+
+
+def initialize_workbook_row() -> pd.core.series.Series:
+    """Initialize a row for the annotation workbook
+    :returns:   A pandas Series with the initialized row
+    """
+    row = dict.fromkeys(list_workbook_columns(), "")
+    return pd.Series(row)

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -6,7 +6,11 @@ import pandas as pd
 from lxml import etree
 from spinneret import workbook
 from spinneret import datasets
-from spinneret.workbook import get_description
+from spinneret.workbook import (
+    get_description,
+    initialize_workbook_row,
+    list_workbook_columns,
+)
 
 
 def test_create():
@@ -73,3 +77,18 @@ def test_get_description_handles_missing_element():
     # Test element with missing abstract
     description = get_description(element)
     assert description == ""
+
+
+def test_list_workbook_columns():
+    """Test the list_workbook_columns function"""
+    res = list_workbook_columns()
+    assert isinstance(res, list)
+    assert len(res) > 0
+
+
+def test_initialize_workbook_row():
+    """Test the initialize_workbook_row function"""
+    res = initialize_workbook_row()
+    assert isinstance(res, pd.core.series.Series)
+    assert res.index.to_list() == list_workbook_columns()
+    assert res.to_list() == [""] * len(res)


### PR DESCRIPTION
Create a function to initialize an empty workbook row to be subsequently filled with content. This provides a foundation for independent annotation operations without relying on an existing workbook, addressing scenarios where a new workbook row needs to be created from scratch.

Currently, annotators create rows of annotation data by copying from an existing workbook then modifying the rows contents.