### PR TITLE
feat: add utility functions for workbook field population

### DIFF
--- a/src/spinneret/workbook.py
+++ b/src/spinneret/workbook.py
@@ -213,3 +213,30 @@ def initialize_workbook_row() -> pd.core.series.Series:
     """
     row = dict.fromkeys(list_workbook_columns(), "")
     return pd.Series(row)
+
+
+def get_package_id(eml: etree._ElementTree) -> str:
+    """
+    :param eml: The EML file as an lxml etree object
+    :returns: The packageId of the EML file
+    """
+    package_id = eml.xpath("./@packageId")[0]
+    return package_id
+
+
+def get_package_url(eml: etree._ElementTree, env: str = "production") -> str:
+    """
+    :param eml: The EML file as an lxml etree object
+    :param env: The environment to use for the base URL. Options are:
+        'production', 'staging', 'development'.
+    :returns: The URL to the data package landing page
+    """
+    if env == "staging":
+        base_url = "https://portal-s.edirepository.org/nis/metadataviewer?packageid="
+    elif env == "development":
+        base_url = "https://portal-d.edirepository.org/nis/metadataviewer?packageid="
+    else:
+        base_url = "https://portal.edirepository.org/nis/metadataviewer?packageid="
+    package_id = get_package_id(eml)
+    url = base_url + package_id
+    return url

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -10,6 +10,8 @@ from spinneret.workbook import (
     get_description,
     initialize_workbook_row,
     list_workbook_columns,
+    get_package_id,
+    get_package_url,
 )
 
 
@@ -92,3 +94,28 @@ def test_initialize_workbook_row():
     assert isinstance(res, pd.core.series.Series)
     assert res.index.to_list() == list_workbook_columns()
     assert res.to_list() == [""] * len(res)
+
+
+def test_get_package_id():
+    """Test the get_package_id function"""
+    eml_file = datasets.get_example_eml_dir() + "/" + "edi.3.9.xml"
+    eml = etree.parse(eml_file)
+    assert get_package_id(eml) == "edi.3.9"
+
+
+def test_get_package_url():
+    """Test the get_package_url function"""
+
+    # Default environment is production
+    eml_file = datasets.get_example_eml_dir() + "/" + "edi.3.9.xml"
+    eml = etree.parse(eml_file)
+    expected_url = (
+        "https://portal.edirepository.org/nis/metadataviewer?packageid=edi.3.9"
+    )
+    assert get_package_url(eml) == expected_url
+
+    # Specify a different environment to get its URL
+    expected_url = (
+        "https://portal-s.edirepository.org/nis/metadataviewer?packageid=edi.3.9"
+    )
+    assert get_package_url(eml, env="staging") == expected_url


### PR DESCRIPTION
Create utility functions to populate workbook fields, promoting code reuse and consistency across various annotators.