### PR TITLE
refactor: integrate workbook row creation

### DIFF
--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -41,7 +41,6 @@ def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
         wb = workbook.create(
             eml_file=eml_dir + "/" + eml_file,
             elements=["dataset", "attribute"],
-            base_url="https://portal.edirepository.org/nis/metadataviewer?packageid=",
             path_out=workbook_dir,
         )
 

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -19,13 +19,11 @@ def test_create():
     """Test workbook creation and attributes"""
 
     # A workbook is created for each EML file
-    eml_dir = datasets.get_example_eml_dir()
-    eml_file = eml_dir + "/" + "edi.3.9.xml"
+    eml_file = datasets.get_example_eml_dir() + "/" + "edi.3.9.xml"
     with tempfile.TemporaryDirectory() as tmpdir:
         wb = workbook.create(
             eml_file=eml_file,
             elements=["dataset", "dataTable", "otherEntity", "attribute"],
-            base_url="https://portal.edirepository.org/nis/metadataviewer?packageid=",
             path_out=tmpdir,
         )
         eml_file_name = os.path.basename(eml_file)


### PR DESCRIPTION
Incorporate the newly created workbook row generation function into the workbook.create function to streamline the process and reduce code duplication.