### PR TITLE
refactor: standardize workbook annotator return types

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -329,9 +329,8 @@ def add_qudt_annotations_to_workbook(
     eml: Union[str, etree._ElementTree],
     output_path: str = None,
     overwrite: bool = False,
-) -> Union[None, pd.core.frame.DataFrame]:
-    """Add QUDT annotations to a workbook
-
+) -> pd.core.frame.DataFrame:
+    """
     :param workbook: Either the path to the workbook to be annotated, or the
         workbook itself as a pandas DataFrame.
     :param eml: Either the path to the EML file corresponding to the workbook,
@@ -340,7 +339,8 @@ def add_qudt_annotations_to_workbook(
     :param overwrite: If True, overwrite existing QUDT annotations in the
         workbook. This enables updating the annotations in the workbook with
         the latest QUDT annotations.
-    :returns: None"""
+    :returns: Workbook with QUDT annotations."""
+
     # Load the workbook and EML for processing
     if isinstance(workbook, str):
         wb = pd.read_csv(workbook, sep="\t", encoding="utf-8", dtype=str)
@@ -383,7 +383,5 @@ def add_qudt_annotations_to_workbook(
             wb.loc[len(wb)] = modified_row
 
     if output_path:
-        # Write the annotated workbook to output_path
         wb.to_csv(output_path, sep="\t", index=False, encoding="utf-8")
-        return None
     return wb

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -201,12 +201,11 @@ def test_add_qudt_annotations_to_workbook(tmp_path, use_mock, mocker):
                 {"label": "latitude", "uri": "http://qudt.org/vocab/unit/DEG"}
             ],
         )
-    add_qudt_annotations_to_workbook(
+    wb = add_qudt_annotations_to_workbook(
         workbook=workbook_path,
         eml=get_example_eml_dir() + "/" + "edi.3.9.xml",
         output_path=output_path,
     )
-    wb = pd.read_csv(output_path, sep="\t", encoding="utf-8")
     assert has_annotations(wb)
 
     # Overwriting changes the annotations. Note, we can't test this with real
@@ -221,13 +220,12 @@ def test_add_qudt_annotations_to_workbook(tmp_path, use_mock, mocker):
                 }
             ],
         )
-        add_qudt_annotations_to_workbook(
+        wb = add_qudt_annotations_to_workbook(
             workbook=output_path,  # the output from the first call
             eml=get_example_eml_dir() + "/" + "edi.3.9.xml",
             output_path=output_path,
             overwrite=True,
         )
-        wb = pd.read_csv(output_path, sep="\t", encoding="utf-8")
         assert "Martha_Stewart" in wb["object"].values
         assert "http://qudt.org/vocab/unit/Martha_Stewart" in wb["object_id"].values
         # Original annotations are gone
@@ -246,7 +244,7 @@ def test_add_qudt_annotations_to_workbook_io_options(tmp_path, mocker):
 
     # Accepts file path as input
     output_path = str(tmp_path) + "edi.3.9_annotation_workbook_qudt.tsv"
-    add_qudt_annotations_to_workbook(
+    wb = add_qudt_annotations_to_workbook(
         workbook="tests/edi.3.9_annotation_workbook.tsv",
         eml=get_example_eml_dir() + "/" + "edi.3.9.xml",
         output_path=output_path,


### PR DESCRIPTION
Modify workbook annotators to consistently return DataFrames, regardless of input arguments. This simplifies code logic and improves function clarity.