### PR TITLE
fix: enhance author attribution in `add_qudt_annotations_to_workbook`

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -359,7 +359,7 @@ def add_qudt_annotations_to_workbook(
             criteria={
                 "element": "attribute",
                 "object_id": "http://qudt.org/vocab/unit/",
-                "author": "Unit Webservice Service",
+                "author": "spinneret.annotator.get_qudt_annotation",
             },
         )
 
@@ -387,7 +387,7 @@ def add_qudt_annotations_to_workbook(
             )
             modified_row["object"] = annotation[0]["label"]
             modified_row["object_id"] = annotation[0]["uri"]
-            modified_row["author"] = "Unit Webservice Service"
+            modified_row["author"] = "spinneret.annotator.get_qudt_annotation"
             modified_row["date"] = pd.Timestamp.now()
             wb.loc[len(wb)] = modified_row
 


### PR DESCRIPTION
Modify the `add_qudt_annotations_to_workbook` function to use a more descriptive author value, providing better provenance. The full module path of the Python function is now used to identify the source of the annotation.