### PR TITLE
fix: remove empty XML tags during EML loading

### DIFF
--- a/src/spinneret/utilities.py
+++ b/src/spinneret/utilities.py
@@ -72,4 +72,5 @@ def load_eml(eml: Union[str, etree._ElementTree]) -> etree._ElementTree:
     """
     if isinstance(eml, str):
         eml = etree.parse(eml, parser=etree.XMLParser(remove_blank_text=True))
+    eml = delete_empty_tags(eml)
     return eml


### PR DESCRIPTION
Remove empty XML tags during the EML loading process to prevent potential errors and inconsistencies in subsequent processing steps.

This was in the code base prior to commit
6847f911d345f231a9aeb2f6e0ba4cac5ef007e0, but not included in the refactor commit 44468ea54b1fde860a0af64cafdf1cd600b5ba0a.