### PR TITLE
feat: implement write_workbook for standardized output

### DIFF
--- a/src/spinneret/utilities.py
+++ b/src/spinneret/utilities.py
@@ -74,3 +74,12 @@ def load_eml(eml: Union[str, etree._ElementTree]) -> etree._ElementTree:
         eml = etree.parse(eml, parser=etree.XMLParser(remove_blank_text=True))
     eml = delete_empty_tags(eml)
     return eml
+
+
+def write_workbook(workbook: pd.core.frame.DataFrame, output_path: str) -> None:
+    """
+    :param workbook: The workbook to be written.
+    :param output_path: The path to write the workbook to.
+    :returns: None
+    """
+    workbook.to_csv(output_path, sep="\t", index=False, encoding="utf-8")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,9 +1,16 @@
 """Test utilities module"""
 
+from os.path import exists
 from lxml import etree
 import pandas as pd
 from spinneret import datasets
-from spinneret.utilities import delete_empty_tags, is_url, load_workbook, load_eml
+from spinneret.utilities import (
+    delete_empty_tags,
+    is_url,
+    load_workbook,
+    load_eml,
+    write_workbook,
+)
 from spinneret.datasets import get_example_eml_dir
 
 
@@ -58,3 +65,13 @@ def test_load_eml():
     eml = load_eml(get_example_eml_dir() + "/" + "edi.3.9.xml")
     eml = load_eml(eml)
     assert isinstance(eml, etree._ElementTree)
+
+
+def test_write_workbook(tmp_path):
+    """Test that a workbook DataFrame is written to a file"""
+    wb = load_workbook("tests/edi.3.9_annotation_workbook.tsv")
+    output_path = str(tmp_path) + "/output.tsv"
+    write_workbook(wb, output_path)
+    assert exists(output_path)  # Check that the file exists
+    wb2 = load_workbook(output_path)  # file contents are the same
+    assert wb.equals(wb2)


### PR DESCRIPTION
Introduce the `write_workbook` function to standardize the output format and avoid unintended data loss.