### PR TITLE
refactor: integrate `write_workbook`

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -14,7 +14,7 @@ from spinneret.workbook import (
     get_subject_and_context,
     get_description,
 )
-from spinneret.utilities import load_eml, load_workbook
+from spinneret.utilities import load_eml, load_workbook, write_workbook
 
 
 # pylint: disable=too-many-locals
@@ -202,7 +202,7 @@ def annotate_workbook(workbook_path: str, output_path: str) -> None:
     wb = pd.concat([wb, wb_additional_rows], ignore_index=True)
 
     # Write the annotated workbook back to the original path
-    wb.to_csv(output_path, sep="\t", index=False, encoding="utf-8")
+    write_workbook(wb, output_path)
 
 
 def annotate_eml(eml_path: str, workbook_path: str, output_path: str) -> None:
@@ -407,5 +407,5 @@ def add_qudt_annotations_to_workbook(
             wb = pd.concat([wb, row], ignore_index=True)
 
     if output_path:
-        wb.to_csv(output_path, sep="\t", index=False, encoding="utf-8")
+        write_workbook(wb, output_path)
     return wb

--- a/src/spinneret/workbook.py
+++ b/src/spinneret/workbook.py
@@ -2,7 +2,7 @@
 
 from lxml import etree
 import pandas as pd
-from spinneret.utilities import delete_empty_tags, load_eml
+from spinneret.utilities import delete_empty_tags, load_eml, write_workbook
 
 
 def create(
@@ -69,7 +69,7 @@ def create(
             wb.loc[len(wb)] = row  # append row to workbook
     if path_out:
         path_out = path_out + "/" + get_package_id(eml) + "_annotation_workbook.tsv"
-        wb.to_csv(path_out, sep="\t", index=False, mode="x")
+        write_workbook(wb, path_out)
     return wb
 
 


### PR DESCRIPTION
Integrate the `write_workbook` function into the codebase to ensure consistent and accurate workbook output.