### PR TITLE
refactor: integrate `write_eml`

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -14,7 +14,7 @@ from spinneret.workbook import (
     get_subject_and_context,
     get_description,
 )
-from spinneret.utilities import load_eml, load_workbook, write_workbook
+from spinneret.utilities import load_eml, load_workbook, write_workbook, write_eml
 
 
 # pylint: disable=too-many-locals
@@ -273,7 +273,7 @@ def annotate_eml(eml_path: str, workbook_path: str, output_path: str) -> None:
                 attribute.insert(len(attribute) + 1, annotation)
 
     # Write eml to file
-    eml.write(output_path, pretty_print=True, encoding="utf-8", xml_declaration=True)
+    write_eml(eml, output_path)
 
 
 def create_annotation_element(predicate_label, predicate_id, object_label, object_id):

--- a/src/spinneret/shadow.py
+++ b/src/spinneret/shadow.py
@@ -2,7 +2,7 @@
 
 from urllib.parse import urljoin
 from lxml import etree
-from spinneret.utilities import is_url, load_eml
+from spinneret.utilities import is_url, load_eml, write_eml
 
 
 def convert_userid_to_url(eml: etree.ElementTree) -> etree.ElementTree:
@@ -46,4 +46,4 @@ def create_shadow_eml(eml_path: str, output_path: str) -> None:
     eml = convert_userid_to_url(eml)
 
     # Write eml to file
-    eml.write(output_path, pretty_print=True, encoding="utf-8", xml_declaration=True)
+    write_eml(eml, output_path)


### PR DESCRIPTION
Integrate the `write_eml` function into the codebase to ensure consistent and accurate EML output.