### PR TITLE
refactor: pass EML to `annotate_workbook` subroutines for context

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -118,11 +118,12 @@ def get_bioportal_annotation(
     return annotations
 
 
-def annotate_workbook(workbook_path: str, output_path: str) -> None:
+def annotate_workbook(workbook_path: str, eml_path: str, output_path: str) -> None:
     """Annotate a workbook with automated annotation
 
     :param workbook_path: The path to the workbook to be annotated
         corresponding to the EML file.
+    :param eml_path: The path to the EML file corresponding to the workbook.
     :param output_path: The path to write the annotated workbook.
     :returns: None
     :notes: The workbook is annotated by annotators best suited for the XPaths

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -45,10 +45,13 @@ def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
         )
 
 
-def annotate_workbooks(workbook_dir: str, output_dir: str, config_path: str) -> None:
+def annotate_workbooks(
+    workbook_dir: str, eml_dir: str, output_dir: str, config_path: str
+) -> None:
     """Create workbooks for each EML file in a directory
 
     :param workbook_dir: Directory of unannotated workbooks
+    :param eml_dir: Directory of EML files corresponding to workbooks
     :param output_dir: Directory to save annotated workbooks
     :param config_path: Path to configuration file
     :return: None
@@ -74,10 +77,18 @@ def annotate_workbooks(workbook_dir: str, output_dir: str, config_path: str) -> 
         if workbook_file_annotated in output_files:
             continue
 
+        # Match EML file to workbook file
+        eml_pid = workbook_file.split("_")[0]
+        eml_file = eml_pid + ".xml"
+        if not os.path.exists(eml_dir + "/" + eml_file):
+            print(f"Could not find EML file for {workbook_file}")
+            continue
+
         # Create annotated workbook
         print(f"Creating annotated workbook for {workbook_file}")
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,
+            eml_path=eml_file,
             output_path=output_dir + "/" + workbook_file_annotated,
         )
 
@@ -295,6 +306,7 @@ if __name__ == "__main__":
 
     # annotate_workbooks(
     #     workbook_dir="/Users/csmith/Data/kgraph/workbook/raw",
+    #     eml_dir="/Users/csmith/Data/kgraph/eml/raw",
     #     output_dir="/Users/csmith/Data/kgraph/workbook/annotated",
     #     config_path="/Users/csmith/Code/spinneret_EDIorg/spinneret/config.json",
     # )

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -107,6 +107,7 @@ def test_annotate_workbook(
     # Annotate the workbook copy
     annotate_workbook(
         workbook_path=wb_path_copy,
+        eml_path=get_example_eml_dir() + "/" + "edi.3.9.xml",
         output_path=wb_path_annotated,
     )
 


### PR DESCRIPTION
Add the EML path to the `annotate_workbook` function to enable context for annotation subroutines like `add_dataset_annotations_to_workbook`. This provides access to the original EML file, enabling the use of descriptive text beyond the workbook's description field.

This is crucial for annotating elements like units, which require information from the EML's raw unit name and which is not listed in the workbook's description field.

This also enables annotators to source descriptive text directly from the authoritative source (i.e. the EML). It's possible the workbook descriptions could fall out of synch with the corresponding EML document and this refactor addresses this.

Note, the description field provides context to human annotators, which would otherwise have to browse data package landing pages, which is arguably much less efficient. So we keep this information in the workbook for now.