### PR TITLE
refactor: annotate workbook by predicate

### DIFF
--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -88,7 +88,7 @@ def annotate_workbooks(
         print(f"Creating annotated workbook for {workbook_file}")
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,
-            eml_path=eml_file,
+            eml_path=eml_dir + "/" + eml_file,
             output_path=output_dir + "/" + workbook_file_annotated,
         )
 


### PR DESCRIPTION
Restructure the `annotate_workbook` function to organize annotation processes by predicate instead of element. This enables more modular addition of different annotation types to the same element, improving code flexibility and maintainability.