### PR TITLE
fix: handle ungrounded IDs gracefully in CURIE expansion

### DIFF
--- a/src/spinneret/utilities.py
+++ b/src/spinneret/utilities.py
@@ -107,6 +107,7 @@ def expand_curie(curie: str) -> str:
         "ENVO": "http://purl.obolibrary.org/obo/ENVO_",
         "BFO": "http://purl.obolibrary.org/obo/BFO_",
         "ENVTHES": "http://vocabs.lter-europe.net/EnvThes/",
+        "AUTO": "AUTO:",  # return ungrounded CURIEs as is
     }
     prefix, suffix = curie.split(":")
     return f"{mapping[prefix]}{suffix}"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -99,3 +99,5 @@ def test_expand_curie():
         expand_curie("ENVTHES:00001203")
         == "http://vocabs.lter-europe.net/EnvThes/00001203"
     )
+    # Ungrounded CURIES should return the original CURIE
+    assert expand_curie("AUTO:00001203") == "AUTO:00001203"


### PR DESCRIPTION
Modify the CURIE expansion process to gracefully handle ungrounded IDs, preventing errors and allowing for downstream processing.