### PR TITLE
feat: enhance get_description to include methods

### DIFF
--- a/src/spinneret/workbook.py
+++ b/src/spinneret/workbook.py
@@ -147,6 +147,9 @@ def get_description(element: etree._Element) -> str:
         description = element.findtext(".//entityName")
     elif element.tag in "attribute":
         description = element.findtext(".//attributeDefinition")
+    elif element.tag in "methods":
+        methods = etree.tostring(element, encoding="utf-8", method="text")
+        description = methods.decode("utf-8").strip()
     else:
         description = None
     return description

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -54,7 +54,7 @@ def test_get_description():
     eml = load_eml(eml_file)
 
     # Elements to test (note dataTable is a general test for data entities)
-    elements = ["dataset", "dataTable", "attribute"]
+    elements = ["dataset", "dataTable", "attribute", "methods"]
 
     # Test each element
     for element in elements:


### PR DESCRIPTION
Extend the `get_description` function to retrieve methods information, providing a unified approach for accessing this data.