### PR TITLE
fix: ensure correct file extension for OntoGPT output

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -589,7 +589,7 @@ def get_ontogpt_annotation(
         template_file = resources.files("spinneret.data.ontogpt.templates").joinpath(
             f"{template}.yaml"
         )
-        output_file = os.path.join(temp_dir, "output.txt")
+        output_file = os.path.join(temp_dir, "output.json")
 
         # Call OntoGPT
         cmd = (


### PR DESCRIPTION
Correct the OntoGPT output file extension to `.json` to align with the expected file format and prevent potential downstream processing issues.