### PR TITLE
refactor: modularize workbook annotation for improved accuracy

### DIFF
--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -46,12 +46,16 @@ def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
 
 
 def annotate_workbooks(
-    workbook_dir: str, eml_dir: str, output_dir: str, config_path: str
+    workbook_dir: str, eml_dir: str, annotator: str, output_dir: str, config_path: str
 ) -> None:
     """Create workbooks for each EML file in a directory
 
     :param workbook_dir: Directory of unannotated workbooks
     :param eml_dir: Directory of EML files corresponding to workbooks
+    :param annotator: The annotator to use for grounding. Options are "ontogpt"
+        and "bioportal". OntoGPT requires setup and configuration described in
+        the `get_ontogpt_annotation` function. Similarly, BioPortal requires
+        an API key and is described in the `get_bioportal_annotation` function.
     :param output_dir: Directory to save annotated workbooks
     :param config_path: Path to configuration file
     :return: None
@@ -89,6 +93,7 @@ def annotate_workbooks(
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,
             eml_path=eml_dir + "/" + eml_file,
+            annotator=annotator,
             output_path=output_dir + "/" + workbook_file_annotated,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@
 import pytest
 
 
-@pytest.fixture(name="get_bioportal_annotation_fixture")
-def get_bioportal_annotation_fixture():
-    """Create a get_bioportal_annotation return value fixture for tests."""
+@pytest.fixture(name="get_annotation_fixture")
+def get_annotation_fixture():
+    """Return a fixture for annotators."""
     return [
         {"label": "a label", "uri": "a uri"},
         {"label": "another label", "uri": "another uri"},


### PR DESCRIPTION
Refactor the workbook annotation process to use modular annotators, enhancing accuracy and precision. The BioPortal annotator is retained as an option for specific use cases.