### PR TITLE
docs: clarify annotation reuse and skipping logic

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -379,7 +379,10 @@ def add_qudt_annotations_to_workbook(
         attribute_xpath = eml.getpath(attribute_element)
         attribute_description = get_description(attribute_element)
 
-        # Reuse annotations if they already exist for sake of efficiency
+        # Reuse existing annotations for elements with identical tag names,
+        # descriptions, and predicate labels, to reduce redundant processing.
+        # Note this assumes semantic equivalence between elements with matching
+        # tags and descriptions.
         annotations = get_annotation_from_workbook(
             workbook=wb,
             element=attribute_element.tag,
@@ -551,7 +554,10 @@ def add_measurement_type_annotations_to_workbook(
         attribute_xpath = eml.getpath(attribute_element)
         attribute_description = get_description(attribute_element)
 
-        # Reuse annotations if they already exist for sake of efficiency
+        # Reuse existing annotations for elements with identical tag names,
+        # descriptions, and predicate labels, to reduce redundant processing.
+        # Note this assumes semantic equivalence between elements with matching
+        # tags and descriptions.
         annotations = get_annotation_from_workbook(
             workbook=wb,
             element=attribute_element.tag,
@@ -1001,7 +1007,10 @@ def add_env_medium_annotations_to_workbook(
         attribute_xpath = eml.getpath(attribute_element)
         attribute_description = get_description(attribute_element)
 
-        # Reuse annotations if they already exist for sake of efficiency
+        # Reuse existing annotations for elements with identical tag names,
+        # descriptions, and predicate labels, to reduce redundant processing.
+        # Note this assumes semantic equivalence between elements with matching
+        # tags and descriptions.
         annotations = get_annotation_from_workbook(
             workbook=wb,
             element=attribute_element.tag,


### PR DESCRIPTION
Update code comments to clarify the distinction between reusing existing annotations from the workbook and skipping re-annotation for elements that have already been annotated.

Related to commit: 7287f3109e747a420ea62cadf4b70a567032bce8