### PR TITLE
fix: prevent OntoGPT cache-related errors by clearing cache

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -680,6 +680,9 @@ def get_ontogpt_annotation(
         if local_model is not None:
             cmd += f"  -m ollama/{local_model}"
         try:
+            # Clear the cache so that the model can derive new annotations
+            cache_path = os.getcwd() + "/.litellm_cache"
+            os.system(f"rm -rf {cache_path}")
             os.system(cmd)
         except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error calling OntoGPT: {e}")


### PR DESCRIPTION
Implement a cache-clearing mechanism before each OntoGPT call to mitigate issues where cached results, particularly those without grounded concepts, could lead to processing errors. This ensures that each call to OntoGPT is fresh and produces reliable results.