### PR TITLE
feat: implement performance metric logging

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -8,6 +8,7 @@ from typing import Union
 from requests import get, exceptions
 import pandas as pd
 from lxml import etree
+from daiquiri import getLogger
 from spinneret.workbook import (
     delete_annotations,
     initialize_workbook_row,
@@ -24,6 +25,8 @@ from spinneret.utilities import (
     write_eml,
     expand_curie,
 )
+
+logger = getLogger(__name__)
 
 # pylint: disable=too-many-lines
 
@@ -85,6 +88,8 @@ def get_bioportal_annotation(
         key can be loaded as an environment variable from the configuration
         file (see `utilities.load_configuration`).
     """
+    logger.info(f"Text contains {len(text.split())} words")
+
     # Construct the query
     url = "https://data.bioontology.org/annotator"
     payload = {
@@ -159,6 +164,7 @@ def annotate_workbook(
         path as the original workbook.
     """
     print(f"Annotating workbook {workbook_path}")
+    logger.info(f"Annotating with {annotator}")
 
     # Ensure the workbook and eml file match to avoid errors
     pid = os.path.basename(workbook_path).split("_")[0]
@@ -388,7 +394,9 @@ def add_qudt_annotations_to_workbook(
     :param output_path: The path to write the annotated workbook.
     :param overwrite: If True, overwrite existing `QUDT` annotations in the
         `workbook, so a fresh set may be created.
-    :returns: Workbook with QUDT annotations."""
+    :returns: Workbook with QUDT annotations.
+    """
+    logger.info("Annotating units")
 
     # Parameters for the function
     predicate = "uses standard"
@@ -484,7 +492,9 @@ def add_dataset_annotations_to_workbook(
         workbook, so a fresh set may be created.
     :param sample_size: Executes multiple replicates of the annotation request
         to reduce variability of outputs. Variability is inherent in OntoGPT.
-    :returns: Workbook with dataset annotations."""
+    :returns: Workbook with dataset annotations.
+    """
+    logger.info("Annotating dataset")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)
@@ -581,7 +591,9 @@ def add_measurement_type_annotations_to_workbook(
         `get_ontogpt_annotation` documentation for details.
     :param sample_size: Executes multiple replicates of the annotation request
         to reduce variability of outputs. Variability is inherent in OntoGPT.
-    :returns: Workbook with measurement type annotations."""
+    :returns: Workbook with measurement type annotations.
+    """
+    logger.info("Annotating measurement type")
 
     # Parameters for the function
     predicate = "contains measurements of type"
@@ -714,6 +726,8 @@ def get_ontogpt_annotation(
         is required to use this function. For more information, see:
         https://monarch-initiative.github.io/ontogpt/.
     """
+    logger.info(f"Text contains {len(text.split())} words")
+
     # OntoGPT transacts in files, so we write the input text to a temporary
     # file and receive the results as a JSON file. Once the results are parsed
     # we can discard the files.
@@ -792,6 +806,7 @@ def add_process_annotations_to_workbook(
         requires setup and configuration described in the
         `get_ontogpt_annotation` function.
     """
+    logger.info("Annotating process")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)
@@ -907,6 +922,7 @@ def add_env_broad_scale_annotations_to_workbook(
         annotations using OntoGPT, which requires setup and configuration
         described in the `get_ontogpt_annotation` function.
     """
+    logger.info("Annotating broad scale environmental context")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)
@@ -1023,6 +1039,7 @@ def add_env_local_scale_annotations_to_workbook(
         annotations using OntoGPT, which requires setup and configuration
         described in the `get_ontogpt_annotation` function.
     """
+    logger.info("Annotating local scale environmental context")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)
@@ -1137,7 +1154,9 @@ def add_env_medium_annotations_to_workbook(
         `get_ontogpt_annotation` documentation for details.
     :param sample_size: Executes multiple replicates of the annotation request
         to reduce variability of outputs. Variability is inherent in OntoGPT.
-    :returns: Workbook with environmental medium annotations."""
+    :returns: Workbook with environmental medium annotations.
+    """
+    logger.info("Annotating environmental medium")
 
     # Parameters for the function
     predicate = "environmental material"
@@ -1255,6 +1274,7 @@ def add_research_topic_annotations_to_workbook(
         requires setup and configuration described in the
         `get_ontogpt_annotation` function.
     """
+    logger.info("Annotating research topic")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)
@@ -1370,6 +1390,7 @@ def add_methods_annotations_to_workbook(
         requires setup and configuration described in the
         `get_ontogpt_annotation` function.
     """
+    logger.info("Annotating methods")
 
     # Load the workbook and EML for processing
     wb = load_workbook(workbook)

--- a/src/spinneret/benchmark.py
+++ b/src/spinneret/benchmark.py
@@ -1,1 +1,36 @@
 """The benchmark module"""
+
+import time
+import tracemalloc
+from contextlib import contextmanager
+from daiquiri import getLogger
+
+
+logger = getLogger(__name__)
+
+
+@contextmanager
+def monitor(name: str) -> None:
+    """
+    Context manager to monitor the duration and memory usage of a function
+    using the `daiquiri` package logger.
+
+    :param name: The name of the function being monitored.
+    :return: None
+    """
+    start_time = time.time()
+    tracemalloc.start()
+    logger.info(f"Starting function '{name}'")
+    try:
+        yield  # The code inside the `with` block runs here
+    except Exception as e:
+        logger.error(f"Function '{name}' raised an exception: {e}")
+        raise
+    finally:
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        duration = time.time() - start_time
+        logger.info(f"Function '{name}' completed in {duration:.4f} seconds")
+        logger.info(
+            f"Memory usage: Current={current / 1024:.2f} KB; Peak={peak / 1024:.2f} KB"
+        )

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from requests import get, codes
 from rdflib import Graph
+import daiquiri
 from soso.main import convert
 from soso.strategies.eml import EML, get_encoding_format
 from soso.utilities import delete_null_values, generate_citation_from_doi
@@ -12,6 +13,9 @@ from spinneret.annotator import annotate_workbook, annotate_eml
 from spinneret.utilities import load_configuration
 from spinneret.graph import create_graph
 from spinneret.shadow import create_shadow_eml
+
+
+logger = daiquiri.getLogger(__name__)
 
 
 def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
@@ -101,6 +105,7 @@ def annotate_workbooks(
             continue
 
         # Create annotated workbook
+        logger.info(f"Creating annotated workbook for {workbook_file}")
         print(f"Creating annotated workbook for {workbook_file}")
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,30 @@
+"""Test benchmark code"""
+
+import logging
+import daiquiri
+from spinneret.benchmark import monitor
+
+
+def test_monitor(tmp_path):
+    """Test the monitor context manager"""
+
+    def example_function():  # to call with monitor
+        return 1 + 1
+
+    log_file = tmp_path / "test.log"  # set up daiquiri logger
+    daiquiri.setup(
+        level=logging.INFO,
+        outputs=(
+            daiquiri.output.File(log_file),
+            "stdout",
+        ),
+    )
+
+    with monitor("example_function"):  # test with monitor context manager
+        example_function()
+
+    with open(log_file, "r", encoding="utf-8") as file:
+        log = file.read()
+    assert "Starting function 'example_function'" in log
+    assert "Function 'example_function' completed in" in log
+    assert "Memory usage: Current=" in log


### PR DESCRIPTION
Add logging for performance metrics to enable in-depth analysis and optimization.

- Create a context manager to log metrics of interest (runtime and memory usage).
- Estimate tokens per LLM call using word count.