### PR TITLE
refactor: replace print statements with logging

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -115,7 +115,7 @@ def get_bioportal_annotation(
         r = get(url, params=payload, timeout=10)
         r.raise_for_status()
     except exceptions.RequestException as e:
-        print(f"Error calling https://data.bioontology.org/annotator: {e}")
+        logger.error(f"Error calling https://data.bioontology.org/annotator: {e}")
         return None
 
     # Parse the results
@@ -126,7 +126,7 @@ def get_bioportal_annotation(
             r = get(self_link, params={"apikey": api_key}, timeout=10)
             r.raise_for_status()
         except exceptions.RequestException as e:
-            print(f"Error calling {self_link}: {e}")
+            logger.error(f"Error calling {self_link}: {e}")
             return None
         uri = r.json().get("@id", None)
         label = r.json().get("prefLabel", None)
@@ -163,14 +163,14 @@ def annotate_workbook(
         in the EML file. The annotated workbook is written back to the same
         path as the original workbook.
     """
-    print(f"Annotating workbook {workbook_path}")
+    logger.info(f"Annotating workbook {workbook_path}")
     logger.info(f"Annotating with {annotator}")
 
     # Ensure the workbook and eml file match to avoid errors
     pid = os.path.basename(workbook_path).split("_")[0]
     eml_file = pid + ".xml"
     if eml_file not in eml_path:
-        print(f"EML file {eml_file} does not match workbook {workbook_path}")
+        logger.warning(f"EML file {eml_file} does not match workbook {workbook_path}")
         return None
 
     # Load the workbook and EML for processing
@@ -366,14 +366,14 @@ def get_qudt_annotation(text: str) -> Union[list, None]:
         r = get(url, timeout=10)
         r.raise_for_status()
     except exceptions.RequestException as e:
-        print(f"Error calling {url}: {e}")
+        logger.error(f"Error calling {url}: {e}")
         return None
     if r.text == "No_Match":
         return None
     try:  # the service has a few JSON encoding bugs
         json = loads(r.text)
     except decoder.JSONDecodeError as e:
-        print(f"Error decoding JSON from {url}: {e}")
+        logger.error(f"Error decoding JSON from {url}: {e}")
         return None
     label = json["qudtLabel"]
     uri = json["qudtURI"]
@@ -753,7 +753,7 @@ def get_ontogpt_annotation(
             os.system(f"rm -rf {cache_path}")
             os.system(cmd)
         except Exception as e:  # pylint: disable=broad-exception-caught
-            print(f"Error calling OntoGPT: {e}")
+            logger.error(f"Error calling OntoGPT: {e}")
             return None
 
         # Parse the results
@@ -761,7 +761,7 @@ def get_ontogpt_annotation(
             with open(output_file, "r", encoding="utf-8") as f:
                 r = load(f)
         except FileNotFoundError as e:
-            print(f"Error reading OntoGPT output file: {e}")
+            logger.error(f"Error reading OntoGPT output file: {e}")
             return None
         named_entities = r.get("named_entities")
         if named_entities is None:  # OntoGPT couldn't find any annotations

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -41,7 +41,7 @@ def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
             continue
 
         # Create workbook
-        print(f"Creating workbook for {eml_file}")
+        logger.info(f"Creating workbook for {eml_file}")
         wb = workbook.create(
             eml_file=eml_dir + "/" + eml_file,
             elements=["dataset", "attribute"],
@@ -101,12 +101,11 @@ def annotate_workbooks(
         eml_pid = workbook_file.split("_")[0]
         eml_file = eml_pid + ".xml"
         if not os.path.exists(eml_dir + "/" + eml_file):
-            print(f"Could not find EML file for {workbook_file}")
+            logger.warning(f"Could not find EML file for {workbook_file}")
             continue
 
         # Create annotated workbook
         logger.info(f"Creating annotated workbook for {workbook_file}")
-        print(f"Creating annotated workbook for {workbook_file}")
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,
             eml_path=eml_dir + "/" + eml_file,
@@ -145,7 +144,7 @@ def annotate_eml_files(workbook_dir: str, eml_dir: str, output_dir: str) -> None
             continue
 
         # Create annotated EML file
-        print(f"Creating annotated EML file for {eml_path}")
+        logger.info(f"Creating annotated EML file for {eml_path}")
         annotate_eml(
             eml=eml_path,
             workbook=workbook_dir + "/" + workbook_file,
@@ -176,7 +175,7 @@ def create_soso_files(eml_dir: str, output_dir: str) -> None:
         soso_file = eml_pid + ".json"
         if soso_file in soso_files:
             continue
-        print(f"Creating SOSO file for {eml_file}")
+        logger.info(f"Creating SOSO file for {eml_file}")
 
         # Add properties that can't be derived from the EML record
         scope, identifier, revision = eml_pid.split(".")
@@ -292,7 +291,7 @@ def create_shadow_eml_files(eml_dir: str, output_dir: str) -> None:
             continue
 
         # Create shadow EML file
-        print(f"Creating shadow EML file for {eml_file}")
+        logger.info(f"Creating shadow EML file for {eml_file}")
         create_shadow_eml(
             eml_path=eml_dir + "/" + eml_file,
             output_path=output_dir + "/" + shadow_file,


### PR DESCRIPTION
Replace print statements with logging statements to enable more structured and persistent output. This change provides flexibility for capturing and analyzing runtime information.