### PR TITLE
fix: update OntoGPT templates to improve grounding

### DIFF
--- a/src/spinneret/data/ontogpt/templates/contains_measurement_of_type.yaml
+++ b/src/spinneret/data/ontogpt/templates/contains_measurement_of_type.yaml
@@ -7,6 +7,7 @@ description: >-
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+#  rdfs: http://www.w3.org/2000/01/rdf-schema#
   ECSO: http://purl.dataone.org/odo/ECSO_
   envmd: http://w3id.org/ontogpt/contains_measurement_of_type
   linkml: https://w3id.org/linkml/
@@ -22,16 +23,16 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      measurement_type:
-        description: the type of scientific measurement (or variable) described in the dataset
+      output:
+        description: >-
+          The measurement type or variable of a dataset
         annotations:
-          prompt: semicolon-separated list of the type of scientific measurement (or variable) described in the dataset
+          prompt: >- 
+            semicolon-separated list of dataset variable names described by the text
         range: Measurement
         multivalued: true
 
   Measurement:
     is_a: NamedEntity
-    id_prefixes:
-      - ECSO
     annotations:
       annotators: bioportal:ECSO

--- a/src/spinneret/data/ontogpt/templates/contains_process.yaml
+++ b/src/spinneret/data/ontogpt/templates/contains_process.yaml
@@ -25,10 +25,11 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      contains_process:
-        description: the environmental process, biological process, or planned process investigated in the study
+      output:
+        description: The environmental or anthropogenic processes of the dataset
         annotations:
-          prompt: semicolon-separated list of the environmental process, biological process, or planned process investigated in the study
+          prompt: >-
+            semicolon-separated list of environmental processes or anthropogenic processes described by the text
         range: ContainsProcess
         multivalued: true
 

--- a/src/spinneret/data/ontogpt/templates/env_broad_scale.yaml
+++ b/src/spinneret/data/ontogpt/templates/env_broad_scale.yaml
@@ -24,27 +24,28 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      env_broad_scale:
-        description: the broad environmental context in which the study was conducted
+      output:
+        description: The broad environmental context of the dataset
         annotations:
-          prompt: semicolon-separated list of broad environmental contexts in which the study was conducted
+          prompt: >- 
+            semicolon-separated list of the large scale environmental systems (e.g. ecosystem, biome)
         range: EnvBroadScale
         multivalued: true
 
   EnvBroadScale:
     is_a: NamedEntity
-    id_prefixes:
-      - ENVO
+#    id_prefixes:
+#      - ENVO
     annotations:
       annotators: sqlite:obo:envo
-    slot_usage:
-      id:
-        values_from:
-          - EnvoEnvironmentalSystem
+#    slot_usage:
+#      id:
+#        values_from:
+#          - EnvoEnvironmentalSystem
 
-enums:
-  EnvoEnvironmentalSystem:
-    reachable_from:
-      source_ontology: obo:envo
-      source_nodes:
-        - ENVO:01000254  # environmental system
+#enums:
+#  EnvoEnvironmentalSystem:
+#    reachable_from:
+#      source_ontology: obo:envo
+#      source_nodes:
+#        - ENVO:01000254  # environmental system

--- a/src/spinneret/data/ontogpt/templates/env_local_scale.yaml
+++ b/src/spinneret/data/ontogpt/templates/env_local_scale.yaml
@@ -24,31 +24,15 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      env_local_scale:
-        description: the local environmental context in which the study was conducted
+      output:
+        description: The local environmental context of the dataset
         annotations:
-          prompt: semicolon-separated list of local environmental contexts in which the study was conducted
+          prompt: semicolon-separated list of the local scale environmental features
         range: EnvLocalScale
         multivalued: true
 
   EnvLocalScale:
     is_a: NamedEntity
-    id_prefixes:
-      - ENVO
     annotations:
       annotators: sqlite:obo:envo
-    slot_usage:
-      id:
-        values_from:
-          - EnvoMaterialEntity
 
-enums:
-  EnvoMaterialEntity:
-    reachable_from:
-      source_ontology: obo:envo
-      source_nodes:  # a selection of nodes from the ENVO `material entity` branch
-        - ENVO:01000813  # astronomical body part
-        - ENVO:01001813  # construction
-        - ENVO:01000408  # environmental zone
-        - ENVO:01003020  # fiat part of an astronomical object
-        - ENVO:01000281  # layer

--- a/src/spinneret/data/ontogpt/templates/env_medium.yaml
+++ b/src/spinneret/data/ontogpt/templates/env_medium.yaml
@@ -23,10 +23,10 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      env_medium:
-        description: the environmental material(s) immediately surrounding the sample or specimen at the time of sampling
+      output:
+        description: The environmental material(s) immediately surrounding the measurement variable at the time of sampling
         annotations:
-          prompt: semicolon-separated list of the environmental material(s) immediately surrounding the sample or specimen at the time of sampling
+          prompt: semicolon-separated list of the environmental material(s) immediately surrounding the measurement variable at the time of sampling
         range: EnvironmentalMedium
         multivalued: true
 

--- a/src/spinneret/data/ontogpt/templates/research_topic.yaml
+++ b/src/spinneret/data/ontogpt/templates/research_topic.yaml
@@ -22,16 +22,14 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      topic:
-        description: the general scientific area of study concerning the sample(s)
+      output:
+        description: The scientific areas of study of the dataset
         annotations:
-          prompt: semicolon-separated list of scientific areas of study concerning the sample(s)
+          prompt: semicolon-separated list of scientific areas of study described by the text
         range: Topic
         multivalued: true
 
   Topic:
     is_a: NamedEntity
-    id_prefixes:
-      - ENVTHES
     annotations:
       annotators: bioportal:ENVTHES

--- a/src/spinneret/data/ontogpt/templates/uses_method.yaml
+++ b/src/spinneret/data/ontogpt/templates/uses_method.yaml
@@ -22,16 +22,16 @@ classes:
   Dataset:
     tree_root: true
     attributes:
-      method:
-        description: the type of method or technique used to gather data
+      output:
+        description: >-
+          The type of method or technique used to create the dataset
         annotations:
-          prompt: semicolon-separated list of the type of method or technique used to gather data
+          prompt: >-
+            semicolon-separated list of the type of method or technique used to create the dataset
         range: Method
         multivalued: true
 
   Method:
     is_a: NamedEntity
-    id_prefixes:
-      - ENVTHES
     annotations:
       annotators: bioportal:ENVTHES


### PR DESCRIPTION
Update templates to improve ontology grounding, specifically:

1. Improve template prompts to produce more accurate and precise results.

2.  Relax vocabulary branch constraints to enable broader capture of concepts outside of the target branch due to relevant concepts appearing in multiple branches within the vocabulary. Do this for all templates except `contains_process` and `env_medium`, where concepts are sufficiently constrained to a single branch.

By doing this we increase our reliance on effective prompts to guide the LLM to extract relevant concepts without extracting irrelevant concepts. The issue of irrelevant concepts may be addressed downstream in an additional post processing step that trims out these concepts.

Note vocabulary constraints don't seem to work in vocabularies using the BioPortal API.

3.  Replace semantically descriptive labels (e.g., `measurement_type`) in templates with less semantically related labels (e.g., `output`). This change mitigates the risk of the LLM misinterpreting labels as placeholders for extracted values, leading to parsing errors and incorrect results.