### PR TITLE
feat: enhance CURIE expansion with expanded prefix map

### DIFF
--- a/src/spinneret/utilities.py
+++ b/src/spinneret/utilities.py
@@ -97,21 +97,21 @@ def write_eml(eml: etree._ElementTree, output_path: str) -> None:
 
 def expand_curie(curie: str) -> str:
     """
+    Expand a CURIE into a URI based on the prefix mappings in the OBO and
+    BioPortal converters.
+
     :param curie: The CURIE to be expanded.
     :returns: The expanded CURIE. Returns the original CURIE if the prefix
         does not have a mapping.
+    :notes: This is a wrapper function around the `prefixmaps` and `curies`
+        libraries.
     """
-    mapping = {
-        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "linkml": "https://w3id.org/linkml/",
-        "ECSO": "http://purl.dataone.org/odo/ECSO_",
-        "ENVO": "http://purl.obolibrary.org/obo/ENVO_",
-        "BFO": "http://purl.obolibrary.org/obo/BFO_",
-        "ENVTHES": "http://vocabs.lter-europe.net/EnvThes/",
-        "AUTO": "AUTO:",  # return ungrounded CURIEs as is
-    }
+    prefixmaps = load_prefixmaps()
     prefix, suffix = curie.split(":")
-    return f"{mapping[prefix]}{suffix}"
+    namespace = prefixmaps[prefixmaps["prefix"] == prefix]["namespace"]
+    if len(namespace) > 0:
+        return f"{namespace.to_string(index=False).strip()}{suffix}"
+    return curie
 
 
 def compress_uri(uri: str) -> str:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -93,6 +93,8 @@ def test_write_eml(tmp_path):
 
 def test_expand_curie():
     """Test that a CURIE is expanded to a URL"""
+
+    # Recognized CURIES should return the corresponding URI
     assert expand_curie("ECSO:00001203") == "http://purl.dataone.org/odo/ECSO_00001203"
     assert (
         expand_curie("ENVO:00001203") == "http://purl.obolibrary.org/obo/ENVO_00001203"
@@ -101,6 +103,11 @@ def test_expand_curie():
         expand_curie("ENVTHES:00001203")
         == "http://vocabs.lter-europe.net/EnvThes/00001203"
     )
+    assert (
+        expand_curie("OBOE:00001203")
+        == "http://ecoinformatics.org/oboe/oboe.1.2/00001203"
+    )
+
     # Ungrounded CURIES should return the original CURIE
     assert expand_curie("AUTO:00001203") == "AUTO:00001203"
 


### PR DESCRIPTION
Updated the `expand_curie` function to utilize a significantly larger prefix map, enabling the expansion of a wider range of CURIEs.