### PR TITLE
fix: handle multiple semicolons in CURIE expansion

### DIFF
--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -112,6 +112,16 @@ def test_expand_curie():
     assert expand_curie("AUTO:00001203") == "AUTO:00001203"
 
 
+def test_expand_curie_handles_multiple_semicolon():
+    """Test that a CURIE with multiple semicolons does not raise an error
+
+    This is an unusual case that has occurred in past integration tests. Not sure
+    what the source of this issue is but are testing for it here.
+    """
+    curie = "ENVO:PATO:00001203"
+    assert expand_curie(curie) == curie
+
+
 def test_compress_uri():
     """Test that a URI is compressed to a CURIE"""
 


### PR DESCRIPTION
Correct the expand_curie function to handle CURIEs containing more than one semicolon, preventing the ValueError: too many values to unpack error.