### PR TITLE
refactor: remove outdated `add_dataset_annotations_to_workbook` function

### DIFF
--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -53,7 +53,6 @@ def create_workbooks(eml_dir: str, workbook_dir: str) -> None:
 def annotate_workbooks(
     workbook_dir: str,
     eml_dir: str,
-    annotator: str,
     output_dir: str,
     config_path: str,
     local_model: str = None,
@@ -65,10 +64,6 @@ def annotate_workbooks(
 
     :param workbook_dir: Directory of unannotated workbooks
     :param eml_dir: Directory of EML files corresponding to workbooks
-    :param annotator: The annotator to use for grounding. Options are "ontogpt"
-        and "bioportal". OntoGPT requires setup and configuration described in
-        the `get_ontogpt_annotation` function. Similarly, BioPortal requires
-        an API key and is described in the `get_bioportal_annotation` function.
     :param output_dir: Directory to save annotated workbooks
     :param config_path: Path to configuration file
     :param local_model: See `get_ontogpt_annotation` documentation for details.
@@ -113,7 +108,6 @@ def annotate_workbooks(
         annotate_workbook(
             workbook_path=workbook_dir + "/" + workbook_file,
             eml_path=eml_dir + "/" + eml_file,
-            annotator=annotator,
             output_path=output_dir + "/" + workbook_file_annotated,
             local_model=local_model,
             temperature=temperature,


### PR DESCRIPTION
Remove the outdated `add_dataset_annotations_to_workbook` function, as it lacks the necessary granularity for predicate-level categorization of semantic annotations, a crucial aspect of our current annotation model.

While alternative approaches exist (e.g., annotating with terms from multiple vocabularies and then categorizing based on branch), the ongoing development and active community support for OntoGPT suggest a more promising long-term solution.