### PR TITLE
build: configure Read the Docs for explicit path to config.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   fail_on_warning: false
+  configuration: docs/source/conf.py
 
 python:
   # Install our python package before building the docs


### PR DESCRIPTION
Update `.readthedocs.yaml` to explicitly specify the path to `config.py`. This ensures proper documentation builds and avoids potential issues with an upcoming deprecation of inferred configuration.