### PR TITLE
build: update geoenvo package to latest version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -80,7 +80,7 @@ dependencies:
   - libjpeg-turbo=3.0.0
   - libkml=1.3.0
   - liblapack=3.9.0
-  - liblzma=5.6.3
+  - liblzma=5.6.4
   - libnghttp2=1.64.0
   - libopenblas=0.3.28
   - libpng=1.6.44
@@ -95,13 +95,13 @@ dependencies:
   - libxslt=1.1.39
   - libzlib=1.3.1
   - llvm-openmp=19.1.4
-  - lxml=5.3.0
+  - lxml=5.3.1
   - lz4-c=1.10.0
   - lzo=2.10
   - mapclassify=2.8.1
   - markdown-it-py=3.0.0
-  - matplotlib=3.10.0
-  - matplotlib-base=3.10.0
+  - matplotlib=3.10.1
+  - matplotlib-base=3.10.1
   - mccabe=0.7.0
   - mdit-py-plugins=0.4.2
   - mdurl=0.1.2
@@ -109,7 +109,7 @@ dependencies:
   - multidict=6.1.0
   - munkres=1.1.4
   - mypy_extensions=1.0.0
-  - myst-parser=4.0.0
+  - myst-parser=4.0.1
   - ncurses=6.5
   - networkx=3.4.2
   - openjpeg=2.5.3
@@ -128,11 +128,10 @@ dependencies:
   - pyogrio=0.10.0
   - pyproj=3.7.1
   - pysocks=1.7.1
-  - pytest=8.3.3
+  - pytest=8.3.5
   - pytest-mock=3.14.0
   - python=3.11.11
   - python-dateutil=2.9.0.post0
-  - python-json-logger=2.0.7
   - python-tzdata=2025.1
   - python_abi=3.11
   - pyyaml=6.0.2
@@ -141,6 +140,7 @@ dependencies:
   - readline=8.2
   - requests=2.32.3
   - requests-toolbelt=1.0.0
+  - roman-numerals-py=3.1.0
   - shapely=2.0.7
   - shellingham=1.5.4
   - six=1.16.0
@@ -204,7 +204,7 @@ dependencies:
       - class-resolver==0.5.2
       - coverage==7.6.1
       - curies==0.9.0
-      - daiquiri==3.2.5.1
+      - daiquiri==3.3.0
       - defusedxml==0.7.1
       - deprecated==1.2.14
       - deprecation==2.1.0
@@ -224,6 +224,7 @@ dependencies:
       - frozenlist==1.5.0
       - fsspec==2024.10.0
       - funowl==0.2.3
+      - geoenvo==0.3.0
       - gilda==1.4.0
       - graphviz==0.20.3
       - h11==0.14.0
@@ -298,6 +299,7 @@ dependencies:
       - pytest-logging==2015.11.4
       - python-dotenv==1.0.1
       - python-gitlab==4.11.1
+      - python-json-logger==3.3.0
       - python-semantic-release==9.8.8
       - pytrie==0.4.0
       - pytz==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ contourpy==1.3.1
 coverage==7.6.1
 curies==0.9.0
 cycler==0.12.1
-daiquiri==3.0.0
+daiquiri==3.3.0
 defusedxml==0.7.1
 Deprecated==1.2.18
 deprecation==2.1.0
@@ -64,6 +64,7 @@ frontend==0.0.3
 frozenlist==1.5.0
 fsspec==2024.10.0
 funowl==0.2.3
+geoenvo==0.3.0
 geopandas==1.0.1
 gilda==1.4.0
 gitdb==4.0.11
@@ -180,7 +181,7 @@ pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-gitlab==4.13.0
-python-json-logger==2.0.7
+python-json-logger==3.3.0
 python-semantic-release==9.21.0
 PyTrie==0.4.0
 pytz==2024.1


### PR DESCRIPTION
Update environment and requirements files to use the latest version of the geoenvo package, enabling access to new features.