### PR TITLE
fix: include data package identifier in geoenvo resolve logs

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -760,7 +760,7 @@ def get_geoenv_response_data(eml: str) -> List[dict]:
         for gc in geographic_coverages:
             geometry = Geometry(loads(gc.to_geojson_geometry()))
             response = resolver.resolve(
-                geometry, identifier, description=gc.description()
+                geometry, identifier=identifier, description=gc.description()
             )
             environments.append(response.data)
     return environments

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -361,8 +361,10 @@ if __name__ == "__main__":
     daiquiri.setup(
         level=logging.INFO,
         outputs=(
-            daiquiri.output.File(
-                "/Users/csmith/Data/testing_geoenvo/small_batch/geoenv_responses/spinneret.log"
+            daiquiri.output.RotatingFile(
+                "/Users/csmith/Data/testing_geoenvo/small_batch/spinneret.log",
+                max_size_bytes=100 * 10**6,  # 100 MB
+                backup_count=0,  # Unlimited backup files
             ),
             "stdout",
         ),
@@ -370,8 +372,8 @@ if __name__ == "__main__":
 
     create_geoenv_data_files(
         eml_dir="/Users/csmith/Data/testing_geoenvo/small_batch/eml",
-        output_dir="/Users/csmith/Data/testing_geoenvo/small_batch/geoenv_responses",
-        overwrite=True,
+        output_dir="/Users/csmith/Data/testing_geoenvo/small_batch/responses",
+        overwrite=False,
     )
 
     # create_workbooks(


### PR DESCRIPTION
Add the data package identifier to the geoenvo resolve operation logging to improve debugging by providing context in log messages.