### PR TITLE
feat: enable data source filtering in create_geoenv_data_files

### DIFF
--- a/src/spinneret/annotator.py
+++ b/src/spinneret/annotator.py
@@ -10,11 +10,6 @@ import pandas as pd
 from lxml import etree
 from daiquiri import getLogger
 from geoenvo.resolver import Resolver
-from geoenvo.data_sources import (
-    WorldTerrestrialEcosystems,
-    EcologicalMarineUnits,
-    EcologicalCoastalUnits,
-)
 from geoenvo.geometry import Geometry
 from spinneret.workbook import (
     delete_annotations,
@@ -730,7 +725,7 @@ def has_annotation(
     return bool(matching_rows.any())
 
 
-def get_geoenv_response_data(eml: str) -> List[dict]:
+def get_geoenv_response_data(eml: str, data_sources: list) -> List[dict]:
     """
     Get `geoenv` response data for each Geographic Coverage in an EML file. The
     data is the raw JSON response from the `geoenv` resolver, which includes
@@ -739,15 +734,11 @@ def get_geoenv_response_data(eml: str) -> List[dict]:
     interest.
 
     :param eml: Path to the EML metadata document in XML format.
+    :param data_sources: A list of geoenvo data sources to use for resolution.
     :return: A list of JSON values returned by the geoenvo.Resolver.resolve
         method.
     """
     # Initialize the resolver
-    data_sources = [
-        WorldTerrestrialEcosystems(),
-        EcologicalMarineUnits(),
-        EcologicalCoastalUnits(),
-    ]
     resolver = Resolver(data_sources)
 
     # Get the list of GeographicCoverage objects

--- a/src/spinneret/main.py
+++ b/src/spinneret/main.py
@@ -327,7 +327,9 @@ def create_kgraph(soso_dir: str, vocabulary_dir: str) -> Graph:
     return kgraph
 
 
-def create_geoenv_data_files(eml_dir: str, output_dir: str, overwrite=False):
+def create_geoenv_data_files(
+    eml_dir: str, output_dir: str, data_sources: list, overwrite=False
+):
     """
     Create GeoEnv data files for each EML file in a directory
     :param eml_dir: Path to directory containing EML files
@@ -347,7 +349,7 @@ def create_geoenv_data_files(eml_dir: str, output_dir: str, overwrite=False):
         logger.info(file)
 
         # Get the GeoEnv response data
-        response = get_geoenv_response_data(file)
+        response = get_geoenv_response_data(file, data_sources=data_sources)
         result = {"data": response}
 
         # Write the data to a file
@@ -357,6 +359,11 @@ def create_geoenv_data_files(eml_dir: str, output_dir: str, overwrite=False):
 
 if __name__ == "__main__":
     import logging
+    from geoenvo.data_sources import (
+        WorldTerrestrialEcosystems,
+        EcologicalMarineUnits,
+        EcologicalCoastalUnits,
+    )
 
     daiquiri.setup(
         level=logging.INFO,
@@ -373,6 +380,11 @@ if __name__ == "__main__":
     create_geoenv_data_files(
         eml_dir="/Users/csmith/Data/testing_geoenvo/small_batch/eml",
         output_dir="/Users/csmith/Data/testing_geoenvo/small_batch/responses",
+        data_sources=[
+            WorldTerrestrialEcosystems(),
+            EcologicalCoastalUnits(),
+            EcologicalMarineUnits(),
+        ],
         overwrite=False,
     )
 

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -6,6 +6,7 @@ from shutil import copyfile
 
 import pandas as pd
 import pytest
+from geoenvo.data_sources import WorldTerrestrialEcosystems
 from lxml import etree
 
 from spinneret import annotator
@@ -504,14 +505,15 @@ def test_get_geoenv_response_data():
     """Test get_geoenv_response_data"""
 
     # Positive test case: EML has geographic coverage
-    eml_file = str(files("spinneret.data.eml").joinpath("edi.3.9.xml"))
-    response = get_geoenv_response_data(eml_file)
+    eml_file = str(files("spinneret.data.eml").joinpath("edi.2.2.xml"))
+    data_source = WorldTerrestrialEcosystems()
+    response = get_geoenv_response_data(eml_file, data_sources=[data_source])
     assert isinstance(response, list)
     for item in response:
         assert isinstance(item, dict)
 
     # Negative test case: EML has no geographic coverage
     eml_file = str(files("spinneret.data.eml").joinpath("edi.3.9_no_geocoverage.xml"))
-    response = get_geoenv_response_data(eml_file)
+    response = get_geoenv_response_data(eml_file, data_sources=[data_source])
     assert isinstance(response, list)
     assert len(response) == 0


### PR DESCRIPTION
Add data source parameters to the create_geoenv_data_files function, allowing for targeted data source selection. This optimizes resource usage by avoiding unnecessary queries against irrelevant data sources.