### PR TITLE
build: update environment to install `geoenvo` from main branch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -328,7 +328,7 @@ dependencies:
       - ruamel-yaml==0.18.10
       - ruamel-yaml-clib==0.2.12
       - s3transfer==0.11.4
-      - scikit-learn==1.6.1
+      - scikit-learn==1.4.2
       - semsql==0.4.0
       - shexjsg==0.8.2
       - sortedcontainers==2.4.0
@@ -336,6 +336,7 @@ dependencies:
       - soupsieve==2.6
       - sparqlslurper==0.5.1
       - sparqlwrapper==2.0.0
+      - spinneret==0.5.0
       - sqlalchemy==2.0.39
       - sqlalchemy-utils==0.38.3
       - sssom==0.4.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -203,7 +203,7 @@ rpds-py==0.23.1
 ruamel.yaml==0.18.10
 ruamel.yaml.clib==0.2.12
 s3transfer==0.11.4
-scikit-learn==1.6.1
+scikit-learn==1.4.2
 scipy==1.15.2
 semsql==0.4.0
 setuptools==75.8.2
@@ -227,6 +227,7 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==1.1.10
+spinneret==0.5.0
 SQLAlchemy==2.0.39
 SQLAlchemy-Utils==0.38.3
 sssom==0.4.15


### PR DESCRIPTION
Update environment files to install the `geoenvo` package from the `main` branch of its GitHub repository, instead of the `development` branch.