### PR TITLE
ci: harmonize black formatting versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,19 +25,11 @@ jobs:
     - name: Install poetry
       uses: snok/install-poetry@v1
     - name: Install package
-      run: poetry install
+      run: poetry install --sync --with dev
 
       # Format code and error on issues. This is an easy check to pass.
-    - uses: psf/black@stable
-      with:
-        jupyter: true
-        src: ./src
-        version: "24.8.0"
-    - uses: psf/black@stable
-      with:
-        jupyter: true
-        src: ./tests
-        version: "24.8.0"
+    - name: Run Black formatter
+      run: poetry run black src/ tests/
 
       # Analyze code but don't error on issues. This check encourages best
       # practices and offers flexibility in adoption.


### PR DESCRIPTION
Ensure CI uses the same Black version as local dev by switching from `psf/black@stable` action to `poetry install --sync --with dev`. This resolves inconsistencies and "works on my machine" issues.