### PR TITLE
build: streamline CVE patching with dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+
+version: 2
+updates:
+  # Enable version updates for pyproject.toml, poetry.lock, and requirements.txt
+  - package-ecosystem: "pip"
+    # Look for files in the `root` directory
+    directory: "/"
+    # Check the pip registry for updates every week
+    schedule:
+      interval: "weekly"
+
+  # Enable version updates for environment.yml
+  - package-ecosystem: "conda"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Streamline CVE patching using the `dependabot.yml` configuration file to enable pull requests that apply to project-preferred environment build files.