### PR TITLE
build: enable Dependabot support for Conda dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 
 version: 2
+enable-beta-ecosystems: true
 updates:
   # Enable version updates for pyproject.toml, poetry.lock, and requirements.txt
   - package-ecosystem: "pip"


### PR DESCRIPTION
Add 'enable-beta-ecosystems: true' to the .github/dependabot.yml configuration to allow Dependabot to process the 'conda' package ecosystem. This is required to resolve the error message: "The enable-beta-ecosystems setting must be true to use the package-ecosystem conda".